### PR TITLE
mpu9250: remove hardfault when running driver 

### DIFF
--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -1404,6 +1404,7 @@ MPU9250::stop()
 
 	} else {
 #ifdef USE_I2C
+		_call_interval = 0;
 		work_cancel(HPWORK, &_work);
 #endif
 	}

--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -248,8 +248,10 @@ MPU9250::~MPU9250()
 	/* make sure we are truly inactive */
 	stop();
 
-	orb_unadvertise(_accel_topic);
-	orb_unadvertise(_gyro->_gyro_topic);
+	if (!_magnetometer_only) {
+		orb_unadvertise(_accel_topic);
+		orb_unadvertise(_gyro->_gyro_topic);
+	}
 
 	/* delete the accel subdriver */
 	delete _accel;
@@ -316,7 +318,6 @@ MPU9250::init()
 		PX4_ERR("Exiting! Device failed to take initialization");
 		return ret;
 	}
-
 
 	if (!_magnetometer_only) {
 
@@ -701,11 +702,6 @@ MPU9250::_set_sample_rate(unsigned desired_sample_rate_hz)
 		_sample_rate = 1100 / div;
 		break;
 	}
-
-	/*
-	 * Adjust pollrate to new sample rate.
-	 */
-	_set_pollrate(_sample_rate);
 }
 
 /*

--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -247,6 +247,7 @@ MPU9250::~MPU9250()
 {
 	/* make sure we are truly inactive */
 	stop();
+	_call_interval = 0;
 
 	if (!_magnetometer_only) {
 		orb_unadvertise(_accel_topic);
@@ -1404,7 +1405,6 @@ MPU9250::stop()
 
 	} else {
 #ifdef USE_I2C
-		_call_interval = 0;
 		work_cancel(HPWORK, &_work);
 #endif
 	}

--- a/src/drivers/imu/mpu9250/mpu9250.cpp
+++ b/src/drivers/imu/mpu9250/mpu9250.cpp
@@ -201,23 +201,25 @@ MPU9250::MPU9250(device::Device *interface, device::Device *mag_interface, const
 		_accel->_device_id.devid_s.address = _interface->get_device_address();
 	}
 
-	/* Prime _gyro with common devid. */
-	/* Set device parameters and make sure parameters of the bus device are adopted */
-	_gyro->_device_id.devid = _accel->_device_id.devid;
-	_gyro->_device_id.devid_s.devtype = DRV_GYR_DEVTYPE_MPU9250;
-	_gyro->_device_id.devid_s.bus_type = _interface->get_device_bus_type();
-	_gyro->_device_id.devid_s.bus = _interface->get_device_bus();
-	_gyro->_device_id.devid_s.address = _interface->get_device_address();
+	if (_gyro != nullptr) {
+		/* Prime _gyro with common devid. */
+		/* Set device parameters and make sure parameters of the bus device are adopted */
+		_gyro->_device_id.devid = 0;
+		_gyro->_device_id.devid_s.devtype = DRV_GYR_DEVTYPE_MPU9250;
+		_gyro->_device_id.devid_s.bus_type = _interface->get_device_bus_type();
+		_gyro->_device_id.devid_s.bus = _interface->get_device_bus();
+		_gyro->_device_id.devid_s.address = _interface->get_device_address();
+	}
 
 	/* Prime _mag with common devid. */
-	_mag->_device_id.devid = _accel->_device_id.devid;
+	_mag->_device_id.devid = 0;
 	_mag->_device_id.devid_s.devtype = DRV_MAG_DEVTYPE_MPU9250;
 	_mag->_device_id.devid_s.bus_type = _interface->get_device_bus_type();
 	_mag->_device_id.devid_s.bus = _interface->get_device_bus();
 	_mag->_device_id.devid_s.address = _interface->get_device_address();
 
 	/* For an independent mag, ensure that it is connected to the i2c bus */
-	_interface->set_device_type(_accel->_device_id.devid_s.devtype);
+	_interface->set_device_type(DRV_ACC_DEVTYPE_MPU9250);
 
 	// default accel scale factors
 	_accel_scale.x_offset = 0;


### PR DESCRIPTION
@flochir these changes solve the hardfaults on fmu-v5. When running the driver with the -M flag the accel and gyro classes were unitialized but used in the mpu9250 constructor. 