### PR TITLE
mpu9250: fix mag rotation, other minor fixes, make format

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -212,9 +212,9 @@ then
 		# sensor heating is available, but we disable it for now
 		param set SENS_EN_THERMAL 0        
         
-        # probe for ICM20948 (Here GPS) on external I2C. Rotation 6 (270° Yaw) is correct
-        # for a Here GNSS mounted in Flight direction
-        mpu9250 -X -M -R 6 start
+		# probe for ICM20948 (Here GPS) on external I2C. Rotation 6 (270 deg yaw)
+		# for the accel and gyro and rotation 4 (180 deg yaw)
+		mpu9250 -X -M -R 6 start
 
 		# external L3GD20H is rotated 180 degrees yaw
 		l3gd20 -X -R 4 start
@@ -342,6 +342,7 @@ then
 
 	# Possible external compasses
 	hmc5883 -C -T -X start
+	mpu9250 -X -M -R 6 start
 
 	# Possible external compasses
 	ist8310 -C -b 1 start

--- a/src/drivers/imu/mpu9250/CMakeLists.txt
+++ b/src/drivers/imu/mpu9250/CMakeLists.txt
@@ -40,7 +40,7 @@ px4_add_module(
 		mpu9250_i2c.cpp
 		mpu9250_spi.cpp
 		main.cpp
-        accel.cpp
+		accel.cpp
 		gyro.cpp
 		mag.cpp
 		mag_i2c.cpp

--- a/src/drivers/imu/mpu9250/mag.cpp
+++ b/src/drivers/imu/mpu9250/mag.cpp
@@ -264,6 +264,10 @@ MPU9250_mag::_measure(struct ak8963_regs data)
 	/* apply user specified rotation */
 	rotate_3f(_parent->_rotation, xraw_f, yraw_f, zraw_f);
 
+	if (_parent->_device_type == MPU_DEVICE_TYPE_ICM20948) {
+		rotate_3f(ROTATION_YAW_270, xraw_f, yraw_f, zraw_f); //offset between accel/gyro and mag on icm20948
+	}
+
 	mrb.x = ((xraw_f * _mag_range_scale * _mag_asa_x) - _mag_scale.x_offset) * _mag_scale.x_scale;
 	mrb.y = ((yraw_f * _mag_range_scale * _mag_asa_y) - _mag_scale.y_offset) * _mag_scale.y_scale;
 	mrb.z = ((zraw_f * _mag_range_scale * _mag_asa_z) - _mag_scale.z_offset) * _mag_scale.z_scale;

--- a/src/drivers/imu/mpu9250/mag.h
+++ b/src/drivers/imu/mpu9250/mag.h
@@ -97,7 +97,7 @@
 #define AK09916_ST1_DOR                         0x02
 
 
-#define AK_MPU_OR_ICM(m,i)					((_parent->_device_type==MPU_DEVICE_TYPE_MPU9250) ? m : i)
+#define AK_MPU_OR_ICM(m,i)					((_parent->_device_type==MPU_DEVICE_TYPE_MPU9250) ? (m) : (i))
 
 
 

--- a/src/drivers/imu/mpu9250/main.cpp
+++ b/src/drivers/imu/mpu9250/main.cpp
@@ -275,11 +275,11 @@ start_bus(struct mpu9250_bus_option &bus, enum Rotation rotation, bool external,
 	 * Doing this through the mag device for the time being - it's always there, even in magnetometer only mode.
 	 * Using accel device for MPU6500.
 	 */
-	if(bus.device_type == MPU_DEVICE_TYPE_MPU6500) {
-	    fd = open(bus.accelpath, O_RDONLY);
-	}
-	else {
-	    fd = open(bus.magpath, O_RDONLY);
+	if (bus.device_type == MPU_DEVICE_TYPE_MPU6500) {
+		fd = open(bus.accelpath, O_RDONLY);
+
+	} else {
+		fd = open(bus.magpath, O_RDONLY);
 	}
 
 	if (fd < 0) {
@@ -332,9 +332,9 @@ start(enum MPU9250_BUS busid, enum Rotation rotation, bool external, bool magnet
 			continue;
 		}
 
-		if(bus_options[i].device_type == MPU_DEVICE_TYPE_MPU6500 && magnetometer_only) {
-		    // prevent starting MPU6500 in magnetometer only mode
-		    continue;
+		if (bus_options[i].device_type == MPU_DEVICE_TYPE_MPU6500 && magnetometer_only) {
+			// prevent starting MPU6500 in magnetometer only mode
+			continue;
 		}
 
 		started |= start_bus(bus_options[i], rotation, external, magnetometer_only);


### PR DESCRIPTION
@flochir I added the the yaw rotation that we were setting from qgc to the mag driver. With this change we can start the driver with -R 6 and have rotation none for compass in qgc. Also fixed a couple of formatting things that @bkueng pointed out.